### PR TITLE
Enforce new line between builtin/global/internal import groups

### DIFF
--- a/packages/eslint-config-base/src/index.js
+++ b/packages/eslint-config-base/src/index.js
@@ -35,6 +35,13 @@ module.exports = {
         allow: ['warn', 'error'],
       },
     ],
+    'import/order': [
+      'error',
+      {
+        groups: [['builtin', 'external', 'internal']],
+        'newlines-between': 'always',
+      },
+    ],
   },
   reportUnusedDisableDirectives: true,
 }


### PR DESCRIPTION
More can be found [here](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md)