### PR TITLE
Remove Prettier from the Stylelint config

### DIFF
--- a/packages/stylelint-config-base/index.js
+++ b/packages/stylelint-config-base/index.js
@@ -2,7 +2,6 @@ module.exports = {
   extends: [
     'stylelint-config-twbs-bootstrap/css',
     'stylelint-config-css-modules',
-    'stylelint-prettier/recommended',
   ],
   rules: {
     'at-rule-no-unknown': [true, { ignoreAtRules: ['extend'] }],
@@ -14,5 +13,6 @@ module.exports = {
       'always',
       { except: ['after-single-line-comment', 'first-nested'] },
     ],
+    'string-quotes': 'single',
   },
 }

--- a/packages/stylelint-config-base/package.json
+++ b/packages/stylelint-config-base/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oacore/stylelint-config-base",
   "version": "1.0.6",
-  "description": "Global stylelint configuration across our projects",
+  "description": "CORE style guide and standard for CSS",
   "author": "CORE Team <dev@core.ac.uk>",
   "homepage": "https://github.com/oacore/configs#readme",
   "license": "MIT",
@@ -12,9 +12,7 @@
   },
   "dependencies": {
     "stylelint-config-css-modules": "^2.2.0",
-    "stylelint-config-prettier": "^8.0.1",
-    "stylelint-config-twbs-bootstrap": "^2.0.3",
-    "stylelint-prettier": "^1.1.2"
+    "stylelint-config-twbs-bootstrap": "^2.0.3"
   },
   "peerDependencies": {
     "stylelint": ">=13.6.0"


### PR DESCRIPTION
Relies on pure Stylelint config based on the Bootstrap's config instead. Removes Prettier dependency.

1. Restores single quote, what is our preference in general.
2. **Breaks** Prettier's leading zero preference: values like `0.5` must be `.5` now; since the leading zero is optional, it's forced to remove it.
3. **Breaks** Prettier's no newline preference: multiline properties require new line after colon from now.
4. **Bumps** the package to the next major version since there are 2 breaking changes.

It requires a release and an update after in the @oacore/design.

---

I recommend to pick up similar changes to JS and remove prettier completely but it's not required. I feel good with the CSS only for now.

@Joozty if you are interested, explore [ESLint formatting rules](https://github.com/prettier/eslint-config-prettier/blob/master/index.js). There are quite a lot, Prettier disables them to avoid conflicts

 If we disable Prettier, we rely completely on Airbnb's style guide and will need to tweak only trailing semicolon.